### PR TITLE
Fix a bug from clicking play button multiple times

### DIFF
--- a/index.js
+++ b/index.js
@@ -441,6 +441,7 @@ function tick() {
 var playing = false;
 
 function play() {
+    if (playing) return;
     playing = true;
     tick();
 }


### PR DESCRIPTION
If you click the play button multiple times, then you can spawn multiple render loops which cause the frame rate to increase each time you click.

This can easily be mitigated with a guard clause in `play()`.